### PR TITLE
Removed a loop.

### DIFF
--- a/systems/betSystem.js
+++ b/systems/betSystem.js
@@ -364,31 +364,30 @@
                 }
                 
                 // Wette aktualisieren (Njnia is Schuld)
-                
-                for (i in betTable) {
-                    bet = betTable[i];
-                    if (sender.equalsIgnoreCase(i)) {
-                        if (bet.amount != betWager || bet.option != betOption) {
-                            
-                            $.inidb.incr('points', sender, bet.amount);
-                            betPot = betPot - bet.amount;
-                                                       
-                            betTable[i] = { 
-                                amount: betWager,
-                                option: betOption
-                            }
-                            
-                            $.inidb.decr('points', sender, betWager); 
-                            betPot = (betPot + betWager);
-                            $.logEvent('betSystem.js', 367, 'Bet updated for: ' + sender + ' wager: ' + betWager + ' option:' + betOption);
-                            $.say($.whisperPrefix(sender) + $.lang.get('betsystem.bet.updated', sender, betWager, betOption));
+                i = sender.toLowerCase()
+                bet = betTable[i];
+                if (bet) {
+                    if (bet.amount != betWager || bet.option != betOption) {
+                        
+                        $.inidb.incr('points', sender, bet.amount);
+                        betPot = betPot - bet.amount;
+                                                   
+                        betTable[i] = { 
+                            amount: betWager,
+                            option: betOption
                         }
-                        else {
-                            $.say($.whisperPrefix(sender) + $.lang.get('betsystem.err.voted'));
-                        }                        
-                        return;
+                        
+                        $.inidb.decr('points', sender, betWager); 
+                        betPot = (betPot + betWager);
+                        $.logEvent('betSystem.js', 367, 'Bet updated for: ' + sender + ' wager: ' + betWager + ' option:' + betOption);
+                        $.say($.whisperPrefix(sender) + $.lang.get('betsystem.bet.updated', sender, betWager, betOption));
                     }
+                    else {
+                        $.say($.whisperPrefix(sender) + $.lang.get('betsystem.err.voted'));
+                    }                        
+                    return;
                 }
+
 
                 $.inidb.decr('points', sender, betWager);
 
@@ -398,7 +397,7 @@
                     betPot = (betPot + betWager);
                 }
 
-                betTable[sender] = {
+                betTable[sender.toLowerCase()] = {
                     amount: betWager,
                     option: betOption
                 };


### PR DESCRIPTION
Removed a loop cause we're using the `betTable` array like a hashmap.
I'm not sure if the `sender.toLowerCase()` in line 367 or 401 is required, as (afaik) twitch is sending all names via IRC in lower case.
The real change is the removal of the loop in line 308 and adding / changeing

``` javascript
i = sender.toLowerCase();
bet = betTable[i];
if (bet) {
```

The rest is just indentation.
One loop less, 9 to go :wink:.
